### PR TITLE
Fixes Error "Cannot find module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng2-gridstack",
   "version": "0.2.1",
   "description": "A gridstack component for Angular2",
-  "main": "index.js",
+  "main": "ng2-gridstack.js",
   "scripts": {
     "prepublish": "tsc"
   },


### PR DESCRIPTION
Webpack cannot find module because it points to non-existing index.js
```
Runtime Error
Cannot find module "ng2-gridstack"
Stack
Error: Cannot find module "ng2-gridstack"
    at Object.257 (http://localhost:8100/build/main.js:371:7)
    at __webpack_require__ (http://localhost:8100/build/vendor.js:55:30)
    at Object.252 (http://localhost:8100/build/main.js:354:70)
    at __webpack_require__ (http://localhost:8100/build/vendor.js:55:30)
    at webpackJsonpCallback (http://localhost:8100/build/vendor.js:26:23)
    at http://localhost:8100/build/main.js:1:1
```